### PR TITLE
Add sphinx-code-block-face and use it for code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In your `rst-mode` buffer call `M-x sphinx-mode` to add all the extra features.
 
 ## Native code-block fontification
 
-Similar to `org-mode`, we provide native emacs fontification of code blocks.
+Similar to `org-mode`, we provide native emacs fontification of code blocks,
+which can be tweaked by changing `sphinx-code-block-face`.
 
 ![fontification](docs/_images/native-fontification.png)

--- a/sphinx-mode.el
+++ b/sphinx-mode.el
@@ -32,6 +32,10 @@
   :group 'editing
   :prefix "sphinx-")
 
+(defface sphinx-code-block-face
+  '((t (:inherit fixed-pitch)))
+  "Face used for code blocks.")
+
 (defun sphinx-fontify-code-block (limit)
   "Fontify code blocks from point to LIMIT."
   (condition-case nil
@@ -49,7 +53,7 @@
           (sphinx-src-font-lock-fontify-block lang block-start block-end)
           (add-face-text-property
            block-highlight-start block-end
-           '(:inherit fixed-pitch :background "#232a2b") 'append)))
+           'sphinx-code-block-face 'append)))
     (error nil)))
 
 


### PR DESCRIPTION
This replaces the hard-coded colours with a dedicated font face,
so that it can be properly tweaked and themed.

Closes #2.