### PR TITLE
[wip] Improve support for different rst code block syntaxes

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,6 +6,7 @@
 
 (depends-on "dash" "2.12.1")
 (depends-on "f")
+(depends-on "s")
 
 (development
   (depends-on "buttercup")

--- a/sample.rst
+++ b/sample.rst
@@ -1,0 +1,46 @@
+============================
+Sample reStructuredText file
+============================
+
+This is a reStructuredText file containing various code blocks.
+
+.. code-block:: elisp
+
+  (use-package rst-mode)
+
+  (use-package sphinx-mode)
+
+
+- Below is a code-block inside an indented list item.
+
+  .. code-block::
+
+    def foo(a=1):
+        pass
+
+    def bar(b=2):
+        pass
+
+This is the concise syntax using double colons::
+
+  def foo():
+      pass
+
+Double colons can also occur on their own line, so that this paragraph
+can end with other punctuation. Nice, isn't it?
+
+::
+
+  def foo():
+      pass
+
+
+.. note::
+
+   This is not a code block, even though it follows a line ending with
+   a double colon.
+
+This is a paragraph that announces a code block that should span to
+the end of the file, but it is missing (or not yet written). While this
+is not valid reStructuredText syntax, it should not cause the
+highlighting to hang or fail::


### PR DESCRIPTION
This adds support for all reStructuredText code block syntaxes:

- `.. code-block::`
- `.. code-block:: language`
- `Example::`
- `::`

The previously used regular expression approach is simplified. Regular
expression searches are only used to find the basic syntax elements.
A new search step finds ‘double colon’ code block syntax in addition
to the ‘code-block::’ syntax.

The logic to figure out the language (now with a default fallback),
and to detect the boundaries of the block to highlight, is now
explicitly written out in elisp, using a helper from the built-in
rst.el. This improves detection for indented blocks. An internal
helper is extracted from the previous code, so that it can be used
for for all code-block syntaxes.

Added a dependency on s.el to use its string functions, and added
more (require) statements to load all used functions.

Added a sample file to aid developing and debugging.

While at it, fix all linter warnings.

Closes #4.