### PR TITLE
Extend syntax highlighting to "uml", "graphviz", "graph" and "digraph" directive.

### DIFF
--- a/sphinx-mode.el
+++ b/sphinx-mode.el
@@ -39,23 +39,29 @@
 (defun sphinx-fontify-code-block (limit)
   "Fontify code blocks from point to LIMIT."
   (condition-case nil
-      (while (re-search-forward "\.\. code-block:: \\(.*?\\)\n\n\\( +\\)" limit t)
+      (while (re-search-forward (concat "\\.\\. \\(.*?\\)::[[:blank:]]*\\(.*?\\)\n"
+                                        "\\([[:blank:]]*:.*?:.*?\n\\)*"
+                                        "\n\\( +\\)")
+                                limit t)
         (let* ((block-start (match-end 0))
-               (block-highlight-start (match-beginning 2))
-               (lang (match-string 1))
-               (prefix (match-string 2))
-               (prefix-search (concat "^" prefix))
+               (block-highlight-start (match-beginning 4))
+               (directive (match-string 1))
+               (value (match-string 2))
+               (prefix (match-string 4))
+               (prefix-search (format "^\\(%s\\|[[:blank:]]*$\\)" prefix))
                block-end)
-          (while (progn
-                   (forward-line)
-                   (looking-at prefix-search)))
-          (setq block-end (point))
-          (sphinx-src-font-lock-fontify-block lang block-start block-end)
-          (add-face-text-property
-           block-highlight-start block-end
-           'sphinx-code-block-face 'append)))
+          (if (assoc directive sphinx-src-directive-mode-function)
+              (progn
+                (while (progn
+                         (forward-line)
+                         (and (< (point) (point-max))
+                              (looking-at prefix-search))))
+                (setq block-end (point))
+                (sphinx-src-font-lock-fontify-block directive value block-start block-end)
+                (add-face-text-property
+                 block-highlight-start block-end
+                 'sphinx-code-block-face 'append)))))
     (error nil)))
-
 
 (defun sphinx--get-refs-from-buffer (&optional buffer)
   "Get all refs from BUFFER.

--- a/sphinx-src.el
+++ b/sphinx-src.el
@@ -53,14 +53,22 @@ LANG is a string, and the returned major mode is a symbol."
       (if (symbolp l) (symbol-name l) l))
     "-mode")))
 
+(setq sphinx-src-directive-mode-function
+  '(("code-block" . sphinx-src--get-lang-mode)
+    ("uml"        . (lambda (value) (intern "plantuml-mode")))
+    ("graphviz"   . (lambda (value) (intern "graphviz-dot-mode")))
+    ("graph"      . (lambda (value) (intern "graphviz-dot-mode")))
+    ("digraph"    . (lambda (value) (intern "graphviz-dot-mode")))
+    ))
+
 ;; This is copy-pasted from org-src.el
-(defun sphinx-src-font-lock-fontify-block (lang start end)
+(defun sphinx-src-font-lock-fontify-block (directive value start end)
   "Fontify code block.
 
 LANG is the language used in the block.
 
 START and END specify the block position."
-  (let ((lang-mode (sphinx-src--get-lang-mode lang)))
+  (let ((lang-mode (funcall (cdr (assoc directive sphinx-src-directive-mode-function)) value)))
     (when (fboundp lang-mode)
       (let ((string (buffer-substring-no-properties start end))
             (modified (buffer-modified-p))


### PR DESCRIPTION
I propose some improvements:

* Syntax for "uml", "graph" ...
* Allow empty line in block
* Allow option after directive

I am sorry, I didn't see there were other pull request.