### PR TITLE
Fixed bug when trying to preview files in subfolders

### DIFF
--- a/sphinx-mode.el
+++ b/sphinx-mode.el
@@ -135,7 +135,7 @@ To see list of target formats, run 'make help' in a shell."
       (let* ((file-rel-path (file-relative-name buffer-file-name project-root-dir))
 (build-directory (expand-file-name (concat project-root-dir "_build/" target-format "/"))))
 	(shell-command (concat "make -C " project-root-dir " " target-format))
-	(concat build-directory (car (file-name-all-completions (file-name-base file-rel-path) build-directory))))))
+	(concat build-directory (file-name-directory file-rel-path) (car (file-name-all-completions (file-name-base file-rel-path) (concat build-directory (file-name-directory file-rel-path))))))))
 
 (defun sphinx-compile-and-view ()
   "Run ‘sphinx-compile’ and view compiled version of current source file with 'xdg-open'."


### PR DESCRIPTION
Previously, the source file's relative path was not incorporated in the
output of `sphinx-compile`, so it was fixed.