### PR TITLE
Remove sphinx-mode-pkg.el and update sphinx-mode.el

### DIFF
--- a/sphinx-mode-pkg.el
+++ b/sphinx-mode-pkg.el
@@ -1,3 +1,0 @@
-(define-package "sphinx-mode" "0.1.0" "Minor mode providing sphinx support."
-  '((f "0.20.0")
-    (dash "2.14.1")))

--- a/sphinx-mode.el
+++ b/sphinx-mode.el
@@ -6,8 +6,7 @@
 ;; Maintainer: Matúš Goljer <matus.goljer@gmail.com>
 ;; Created: 11th September 2016
 ;; Keywords: languages
-;; Package-requires: ((dash "2.14.0") (f "0.20"))
-
+;; Package-Requires: ((dash "2.14.1") (f "0.20"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License


### PR DESCRIPTION
The information in `<name>-pkg.el` did not agree with the information in `<name>.el`.  This pull-requests addresses that be removing the outdated `<name>-pkg.el`.

While the end-user package manager `package.el` expects a file `<name>-pkg.el`, this should only be generate by the package archive (such as GNU ELPA and MELPA), instead of being tracked in the upstream repository.

The tools used maintain the various *ELPA, do *not* use `<name>-pkg.el` as a data *source*, they only generate it.

- `elpa-admin.el`, the tool used for GNU ELPA and NonGNU ELPA, does *not* use `<name>-pkg.el` as a data source and it never has.

- `package-build.el`, the tool used for Melpa, prefers `<name>.el` but *currently* falls back to get information missing from there from `<name>-pkg.el` instead. I am goint to change that; soon `<name>-pkg.el` will be ignored as a data source by this tool too.